### PR TITLE
fix(index.html): match only on end of path

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -114,7 +114,7 @@
         document.querySelectorAll(".toc a").forEach((item) => {
             item.classList.remove("active");
         });
-        document.querySelector(".toc a[href='" + pathname + "#" + heading + "']").classList.add("active");
+        document.querySelector(".toc a[href$='" + pathname + "#" + heading + "']").classList.add("active");
     }
 
     let currentHeading = "";


### PR DESCRIPTION
Otherwise, document.querySelector will return a null value when trying
to patch on an entire path.