### PR TITLE
Fix padding for multiline code blocks

### DIFF
--- a/sass/_markdown.scss
+++ b/sass/_markdown.scss
@@ -22,8 +22,12 @@
   color: #4a4a4a;
   font-size: .875em;
   font-weight: normal;
-  padding: 0.25em 0.5em 0.25em;
+  padding: 0.25em 0.5em;
   font-family: monospace;
+}
+
+.content pre code {
+  padding: 0;
 }
 
 .content a {


### PR DESCRIPTION
Before (there's some space before the first $ sign):
![image](https://user-images.githubusercontent.com/7175914/113559319-6c3cf500-9601-11eb-9472-44ee750a4cf1.png)

After:
![image](https://user-images.githubusercontent.com/7175914/113558890-bec9e180-9600-11eb-8d5f-d02e8864b8aa.png)

