### PR TITLE
Fix footer if the content is too small

### DIFF
--- a/sass/juice.scss
+++ b/sass/juice.scss
@@ -7,10 +7,9 @@ body {
   margin: 0;
   box-sizing: border-box;
   background-color: var(--secondary-color);
-  justify-content:space-between;
-  display:flex;
-  flex-direction:column;
-  min-height:100vh;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 a {
@@ -84,6 +83,7 @@ header {
 main {
   display: flex;
   padding: 50px 100px;
+  flex-grow: 1;
 
   .toc {
     max-width: 260px;

--- a/sass/juice.scss
+++ b/sass/juice.scss
@@ -7,6 +7,10 @@ body {
   margin: 0;
   box-sizing: border-box;
   background-color: var(--secondary-color);
+  justify-content:space-between;
+  display:flex;
+  flex-direction:column;
+  min-height:100vh;
 }
 
 a {


### PR DESCRIPTION
before 
<img width="1706" alt="Screenshot 2021-09-15 at 09 16 03" src="https://user-images.githubusercontent.com/6567687/133385221-7cb6ba53-8621-4f91-8ff8-a15537200106.png">


after
<img width="1242" alt="Screenshot 2021-09-15 at 09 54 56" src="https://user-images.githubusercontent.com/6567687/133385258-e68a24ce-9ab1-4d23-8bf7-87b45c1ba20e.png">
