### PR TITLE
Avoid escaping `permalink`s and `menu.link`

### DIFF
--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -1,6 +1,6 @@
 {% macro render_header() %}
 {% set section = get_section(path="_index.md") %}
-<a href="{{ section.permalink }}">
+<a href="{{ section.permalink | safe }}">
     <div class="logo">
         <img src="{{ get_url(path=config.extra.juice_logo_path) }}" alt="logo">
         {{ config.extra.juice_logo_name }}
@@ -9,11 +9,11 @@
 
 <nav>
     {% for page in section.pages %}
-    <a class="nav-item subtitle-text" href="{{ page.permalink }}">{{ page.title }}</a>
+    <a class="nav-item subtitle-text" href="{{ page.permalink | safe }}">{{ page.title }}</a>
     {% endfor %}
     {% if config.extra.juice_extra_menu %}
         {% for menu in config.extra.juice_extra_menu %}
-        <a class="nav-item subtitle-text" href="{{ menu.link }}">{{ menu.title }}</a>
+        <a class="nav-item subtitle-text" href="{{ menu.link | safe }}">{{ menu.title }}</a>
         {% endfor %}
     {% endif %}
 </nav>


### PR DESCRIPTION
`permalik`s are already valid urls, and assume user-configured `menu.link`s in `{% for menu in config.extra.juice_extra_menu %}` are valid as well, we can safely add Tera filter `safe` to prevent escaping.

Currently, `/` in a such valid url will be replaced by `&#x2F;`.

Docs for filter `safe`
 - https://www.getzola.org/documentation/getting-started/overview/#templates
 - https://tera.netlify.app/docs/#safe