### PR TITLE
Allow excluding pages from the nav section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Build for product sites
 - Simple and intuitive structure
-- Clean and elegant design 
+- Clean and elegant design
 - Responsive and mobile device compatible
 - Customize and extend friendly
 
@@ -51,7 +51,7 @@ You can customize your **hero** by using `hero` block in the `index.html`.
 ### Page
 
 Every markdown file located in `content` directory will become a **Page**. There also will display as
-a navigate link on the top-right corner. 
+a navigate link on the top-right corner.
 You can change the frontmatter's `weight` value to sort the order (ascending order).
 
 ```
@@ -104,6 +104,9 @@ juice_logo_name = "Juice"
 juice_logo_path = "juice.svg"
 juice_extra_menu = [
     { title = "Github", link = "https://github.com/huhu/juice"}
+]
+juice_exclude_menu = [
+    "exclude_from_nav"
 ]
 repository_url = "https://github.com/huhu/juice"
 ```

--- a/config.toml
+++ b/config.toml
@@ -22,4 +22,8 @@ juice_logo_path = "juice.svg"
 juice_extra_menu = [
     { title = "Github", link = "https://github.com/huhu/juice" }
 ]
+# Add page titles here to exclude them from the nav section (case sensitive)
+juice_exclude_menu = [
+    "exclude_from_nav"
+]
 repository_url = "https://github.com/huhu/juice"

--- a/content/exclude_from_nav.md
+++ b/content/exclude_from_nav.md
@@ -1,0 +1,8 @@
++++
+title = "exclude_from_nav"
+description = "Page without nav link"
++++
+
+# Hidden page
+
+This page will not be added to the nav links in the header.

--- a/content/exclude_from_nav.md
+++ b/content/exclude_from_nav.md
@@ -1,6 +1,7 @@
 +++
 title = "exclude_from_nav"
 description = "Page without nav link"
+weight = 3
 +++
 
 # Hidden page

--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -9,7 +9,9 @@
 
 <nav>
     {% for page in section.pages %}
+    {% if config.extra.juice_exclude_menu is not containing(page.title) %}
     <a class="nav-item subtitle-text" href="{{ page.permalink | safe }}">{{ page.title }}</a>
+    {% endif %}
     {% endfor %}
     {% if config.extra.juice_extra_menu %}
         {% for menu in config.extra.juice_extra_menu %}


### PR DESCRIPTION
Use a `juice_exclude_menu` field in the `config.toml` file to exclude pages from the nav section in the header using the page titles.

Resolves: #12