### PR TITLE
Uses the language defined in the config file.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@
 base_url = "/"
 
 title = "Juice - An intuitive, elegant, and lightweight Zola theme for product sites."
+# default_language = "en"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% import "_macros.html" as macros %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}">
 
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
In the header of the template was the language hardcoded. This patch uses the `lang`-variable, settable in every page or in `config.toml` as `default_lang`-variable for the hole site (defaults to `en` if unset).